### PR TITLE
Use npm ci instead of npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 ADD package.json package-lock.json .
 
 # Install dependencies
-RUN npm install
+RUN npm ci
 
 COPY public public
 COPY src src


### PR DESCRIPTION
Which will install exact versions from package-lock, instead of installing the most compatible version.

> This command is similar to npm install, except it's meant to be used in automated environments such as test platforms, continuous integration, and deployment -- or any situation where you want to make sure you're doing a clean install of your dependencies. [source](https://docs.npmjs.com/cli/v8/commands/npm-ci#:~:text=This%20command%20is%20similar%20to%20npm%20install%2C%20except%20it%27s%20meant%20to%20be%20used%20in%20automated%20environments%20such%20as%20test%20platforms%2C%20continuous%20integration%2C%20and%20deployment%20%2D%2D%20or%20any%20situation%20where%20you%20want%20to%20make%20sure%20you%27re%20doing%20a%20clean%20install%20of%20your%20dependencies.)